### PR TITLE
Update AUS - Austria.txt

### DIFF
--- a/EEM/history/countries/AUS - Austria.txt
+++ b/EEM/history/countries/AUS - Austria.txt
@@ -1,5 +1,6 @@
 capital = 619
 primary_culture = south_german
+culture = north_german
 religion = catholic
 government = absolute_monarchy
 plurality = 10.0


### PR DESCRIPTION
Adds North German to accepted cultures for Austria (which should then be removed if they enact the Compromise) as an Austria seeking to unify Germany would not realistically discriminate against half the German people (and less so than Bismarck's Prussia, which accepts South German from the start despite his negative attitude towards Catholic Germans).